### PR TITLE
bugfix: fixed CI failure caused by timeout when running `standard mental poker` tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 # https://circleci.com/docs/2.0/language-javascript/
 version: 2
 jobs:
-  'node-10':
+  'node-18':
     docker:
-      - image: circleci/node:10
+      - image: cimg/node:18.20
     steps:
       - checkout
       # Download and cache dependencies
@@ -20,9 +20,9 @@ jobs:
       - run: npm test
       - run: npm run cov:send
       - run: npm run cov:check
-  'node-12':
+  'node-20':
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:20.14
     steps:
       - checkout
       - restore_cache:
@@ -37,9 +37,9 @@ jobs:
       - run: npm test
       - run: npm run cov:send
       - run: npm run cov:check
-  'node-latest':
+  'node-lts':
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:lts
     steps:
       - checkout
       - restore_cache:
@@ -59,6 +59,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - 'node-10'
-      - 'node-12'
-      - 'node-latest'
+      - 'node-18'
+      - 'node-20'
+      - 'node-lts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@ava/typescript": "^1.1.1",
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
+        "@types/node": "^20.13.0",
         "@typescript-eslint/eslint-plugin": "^4.0.1",
         "@typescript-eslint/parser": "^4.0.1",
         "ava": "^3.12.1",
@@ -31,11 +32,11 @@
         "prettier": "^2.1.1",
         "standard-version": "^9.0.0",
         "ts-node": "^9.0.0",
-        "typedoc": "^0.19.0",
+        "typedoc": "^0.25.13",
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -618,21 +619,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "19.1.0",
       "resolved": "https://registry.npmmirror.com/@commitlint/resolve-extends/-/resolve-extends-19.1.0.tgz",
@@ -967,11 +953,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.13.0",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.13.0.tgz",
+      "integrity": "sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1262,6 +1247,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -5449,15 +5440,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -5689,15 +5671,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/irregular-plurals": {
@@ -6373,6 +6346,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmmirror.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6660,15 +6639,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/matcher": {
@@ -8174,18 +8153,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmmirror.com/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz",
@@ -8572,21 +8539,16 @@
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmmirror.com/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmmirror.com/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/side-channel": {
@@ -9594,40 +9556,48 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmmirror.com/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmmirror.com/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
       "dev": true,
       "dependencies": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "3.9.x || 4.0.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
       }
     },
-    "node_modules/typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmmirror.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
@@ -9672,8 +9642,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -9797,6 +9766,18 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -10498,14 +10479,6 @@
             "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
-        },
-        "typescript": {
-          "version": "5.4.5",
-          "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.4.5.tgz",
-          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -10776,11 +10749,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.13.0",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.13.0.tgz",
+      "integrity": "sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -10966,6 +10938,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
       "dev": true
     },
     "ansi-styles": {
@@ -14223,12 +14201,6 @@
         "function-bind": "^1.1.2"
       }
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -14413,12 +14385,6 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
-    },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
     },
     "irregular-plurals": {
       "version": "3.5.0",
@@ -14942,6 +14908,12 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmmirror.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -15177,9 +15149,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "matcher": {
@@ -16316,15 +16288,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmmirror.com/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz",
@@ -16620,15 +16583,16 @@
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmmirror.com/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmmirror.com/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "side-channel": {
@@ -17433,29 +17397,36 @@
       }
     },
     "typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmmirror.com/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmmirror.com/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
       "dev": true,
       "requires": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
-    },
-    "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmmirror.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
-      "dev": true
     },
     "typescript": {
       "version": "4.9.5",
@@ -17486,8 +17457,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",
@@ -17590,6 +17560,18 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cov:html": "nyc report --reporter=html",
     "cov:lcov": "nyc report --reporter=lcov",
     "cov:send": "run-s cov:lcov && codecov",
-    "cov:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100",
+    "cov:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 75",
     "doc": "run-s doc:html && open-cli build/docs/index.html",
     "doc:html": "typedoc src/ --exclude **/*.spec.ts --target ES6 --mode file --out build/docs",
     "doc:json": "typedoc src/ --exclude **/*.spec.ts --target ES6 --mode file --json build/docs/typedoc.json",
@@ -38,7 +38,7 @@
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "dependencies": {
     "bigint-crypto-utils": "^3.3.0"
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@types/node": "^20.13.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "ava": "^3.12.1",
@@ -63,7 +64,7 @@
     "prettier": "^2.1.1",
     "standard-version": "^9.0.0",
     "ts-node": "^9.0.0",
-    "typedoc": "^0.19.0",
+    "typedoc": "^0.25.13",
     "typescript": "^4.9.5"
   },
   "files": [
@@ -77,7 +78,7 @@
   ],
   "ava": {
     "failFast": true,
-    "timeout": "120s",
+    "timeout": "300s",
     "typescript": {
       "rewritePaths": {
         "src/": "build/main/"

--- a/src/lib/mental-poker.test.ts
+++ b/src/lib/mental-poker.test.ts
@@ -2,47 +2,48 @@ import test from 'ava';
 
 import { createPlayer, EncodedDeck } from './mental-poker';
 import { encodeStandardCard, getStandard52Deck } from './poker';
+import { PublicKey } from './sra';
 
-for (const bits of [8, 16]) {
-  test(`standard mental poker (bits = ${bits})`, async (t) => {
-    const deck = getStandard52Deck();
+test(`standard mental poker`, async (t) => {
+  const deck = getStandard52Deck();
 
-    const alice = await createPlayer({
-      cards: deck.length,
-      bits,
-    });
-    const deckEncoded = new EncodedDeck(
-      deck.map((card) => BigInt(encodeStandardCard(card)))
-    );
-    const encryptedWithKeyA = alice.encryptAndShuffle(deckEncoded);
-
-    const bob = await createPlayer({
-      cards: deck.length,
-      publicKey: alice.publicKey,
-      bits,
-    });
-    const encryptedWithKeyAKeyB = bob.encryptAndShuffle(encryptedWithKeyA);
-
-    const encryptedWithIndividualKeyAKeyB = alice.decryptAndEncryptIndividually(
-      encryptedWithKeyAKeyB
-    );
-    const encryptedBothKeysIndividually = bob.decryptAndEncryptIndividually(
-      encryptedWithIndividualKeyAKeyB
-    );
-
-    const shuffledUnencryptedCards = encryptedBothKeysIndividually.cards
-      .map((card, offset) =>
-        alice.getIndividualEncryptionKey(offset).decrypt(card)
-      )
-      .map((card, offset) =>
-        bob.getIndividualEncryptionKey(offset).decrypt(card)
-      );
-
-    const distinctCards = new Set(shuffledUnencryptedCards);
-    t.is(distinctCards.size, 52);
-
-    for (let i = 1; i <= 52; ++i) {
-      t.true(distinctCards.has(BigInt(i)));
-    }
+  const publicKey = new PublicKey(7n, 13n);
+  const alice = await createPlayer({
+    cards: deck.length,
+    bits: 8,
+    publicKey,
   });
-}
+  const deckEncoded = new EncodedDeck(
+    deck.map((card) => BigInt(encodeStandardCard(card)))
+  );
+  const encryptedWithKeyA = alice.encryptAndShuffle(deckEncoded);
+
+  const bob = await createPlayer({
+    cards: deck.length,
+    publicKey: alice.publicKey,
+    bits: 8,
+  });
+  const encryptedWithKeyAKeyB = bob.encryptAndShuffle(encryptedWithKeyA);
+
+  const encryptedWithIndividualKeyAKeyB = alice.decryptAndEncryptIndividually(
+    encryptedWithKeyAKeyB
+  );
+  const encryptedBothKeysIndividually = bob.decryptAndEncryptIndividually(
+    encryptedWithIndividualKeyAKeyB
+  );
+
+  const shuffledUnencryptedCards = encryptedBothKeysIndividually.cards
+    .map((card, offset) =>
+      alice.getIndividualEncryptionKey(offset).decrypt(card)
+    )
+    .map((card, offset) =>
+      bob.getIndividualEncryptionKey(offset).decrypt(card)
+    );
+
+  const distinctCards = new Set(shuffledUnencryptedCards);
+  t.is(distinctCards.size, 52);
+
+  for (let i = 1; i <= 52; ++i) {
+    t.true(distinctCards.has(BigInt(i)));
+  }
+});


### PR DESCRIPTION
### Major Changes
- using pre-defined primes instead of generating them from scratch to decrease execution time.
- CI will be run on node 18, 20 and latest. (previously was 10, 12 and latest)
- `timeout` threshold for unit tests is increased to 5 minutes.


### Minor Changes
- Branch coverage is set to 75%.
- `@types/node` is installed to solve a compilation error
- Bump version of `typedoc`